### PR TITLE
feature get all questions based on a specific meetup

### DIFF
--- a/server/models/question.js
+++ b/server/models/question.js
@@ -1,0 +1,34 @@
+
+//array to hold questions
+const questions = [
+	{
+		id: 1, 
+		createdOn: '12/12/2018', 
+		createdBy: 2, 
+		meetup: "2", 
+		title: 'bootcamp', 
+		bodyy: 'when is the bootcamp schedured',
+		upvote: 0,
+		downvote: 0
+	},
+	{
+		id: 2, 
+		createdOn: '12/12/2018', 
+		createdBy: 1, 
+		meetup:"2", 
+		title: 'frank joe', 
+		bodyy: 'who will be our chairman',
+		upvote: 0,
+		downvote: 0,
+		state:[
+			{
+				id: 1,
+				user: 2,
+				action: 1,
+				
+			}
+		]
+	},
+];
+
+module.exports = questions


### PR DESCRIPTION
#### What does this PR do?
This PR allows us to get questions that were asked to specific meetup
#### Description of Task to be completed?
Returning all the questions
#### How should this be manually tested?
localhost:3000/api/v1/meetups/:id/questions
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
users should be able to see questions for specific meetup #163338052
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/33962360/51414669-ea756400-1b7b-11e9-9699-025e91a97bfc.png)

#### Questions:
