### PR TITLE
adding feature get all comments belonging to a question

### DIFF
--- a/server/controllers/question.js
+++ b/server/controllers/question.js
@@ -113,6 +113,13 @@ downvote (req, res)  {
   }// end of upvote a question.
   
 
+//get all comments for a question
+getComments (req, res) {
+  res.status(200).json({
+    status: 200
+  });
+}
+
 
 
 }

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -11,6 +11,7 @@ routers.post('/meetups/:meetupId/rsvp', meetupControllers.rsvp);//cool
 
 routers.patch('/questions/:questionId/downvote', questionControllers.downvote);
 routers.patch('/questions/:questionId/upvote', questionControllers.upvote);
+routers.get('/questions/:questionId/comments', questionControllers.getComments)
 routers.get('/meetups/:meetupId', meetupControllers.getsingleMeetup);
 routers.delete('/meetups/:meetupId', meetupControllers.deleteMeetup);
 


### PR DESCRIPTION
#### What does this PR do?
This PR allows getting all comments that where asked to that question
#### Description of Task to be completed?
We might have no need of this endpoint since selecting questions from the database we have to join tables first with comments table 
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
Users should be able to see comments posted to a question #163341830
#### Screenshots (if appropriate)
#### Questions:
